### PR TITLE
Allow controlling the bufio reader and writer size per conn via --read-buffer-each-conn and --write-buffer-each-conn

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -3,11 +3,33 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/rueian/rueidis"
 	"log"
 	"net"
 	"os"
 	"time"
 )
+
+func getClientWithOptions(connectionStr, auth string, blockingPoolSize, readBufferEachConn, writeBufferEachConn int, clientKeepAlive time.Duration) rueidis.Client {
+	clientOptions := rueidis.ClientOption{
+		InitAddress:         []string{connectionStr},
+		Password:            auth,
+		AlwaysPipelining:    false,
+		AlwaysRESP2:         true,
+		DisableCache:        true,
+		BlockingPoolSize:    blockingPoolSize,
+		PipelineMultiplex:   0,
+		RingScaleEachConn:   1,
+		ReadBufferEachConn:  readBufferEachConn,
+		WriteBufferEachConn: writeBufferEachConn,
+	}
+	clientOptions.Dialer.KeepAlive = clientKeepAlive
+	client, err := rueidis.NewClient(clientOptions)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
 
 func resolveHostnames(nameserver, host string, ctx context.Context) []net.IP {
 	ips := make([]net.IP, 0)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/rueian/rueidis"
 	"os"
 	"time"
 
@@ -81,5 +82,6 @@ func init() {
 	rootCmd.PersistentFlags().String("resp", "", "redis command response protocol (2 - RESP 2, 3 - RESP 3). If empty will not enforce it.")
 	rootCmd.PersistentFlags().String("nameserver", "", "the IP address of the DNS name server. The IP address can be an IPv4 or an IPv6 address. If empty will use the default host namserver.")
 	rootCmd.PersistentFlags().String("json-out-file", "", "Results file. If empty will not save.")
-
+	rootCmd.PersistentFlags().Int("read-buffer-each-conn", rueidis.DefaultReadBuffer, "the size of the bufio.NewReaderSize for each connection, default to DefaultReadBuffer (0.5 MiB).")
+	rootCmd.PersistentFlags().Int("write-buffer-each-conn", rueidis.DefaultWriteBuffer, "the size of the bufio.NewWriterSize for each connection, default to DefaultWriteBuffer (0.5 MiB).")
 }


### PR DESCRIPTION
On a large scale benchmark (with thousands of connections) we see that bufio buffers consume nearly 100GB. 
This PR introduces a way to reduce this overhead via `--read-buffer-each-conn` and `--write-buffer-each-conn`.

here's a sample profile of the large scale benchmark
![image](https://github.com/redis-performance/openstreaming-benchmark/assets/5832149/8c6279be-74f0-4218-acf5-05978544c692)
